### PR TITLE
LPS-88382 Stick to an older version of our gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	dependencies {
-		classpath group: "com.liferay", name: "com.liferay.gradle.plugins.defaults", version: "latest.release"
+		classpath group: "com.liferay", name: "com.liferay.gradle.plugins.defaults", version: "5.5.150"
 	}
 
 	repositories {


### PR DESCRIPTION
The newest version includes LPS-88382, which makes our web modules
require the JSTL Core capability to be explicitly provided in
portal, which won't happen until 7.1.1 GA3 or later.

This may fail CI, we'll see.