### PR TITLE
Update data integration manager processes model permission

### DIFF
--- a/commerce-data-integration-manager-service/src/main/resources/resource-actions/default.xml
+++ b/commerce-data-integration-manager-service/src/main/resources/resource-actions/default.xml
@@ -23,7 +23,7 @@
 		</permissions>
 	</portlet-resource>
 	<model-resource>
-		<model-name>com.liferay.commerce.data.integration.manager</model-name>
+		<model-name>com.liferay.commerce.data.integration.manager.process</model-name>
 		<portlet-ref>
 			<portlet-name>com_liferay_commerce_data_integration_manager_web_internal_portlet_CommerceDataIntegrationManagerPortlet</portlet-name>
 		</portlet-ref>


### PR DESCRIPTION
When viewing the Processes tab of the Data Integration Admin portlet, it throws a com.liferay.portal.kernel.exception.NoSuchResourcePermissionException. Updating this model-resource name fixes the problem, but I do not know if the original name was intentional or an accident.