### PR TITLE
COMMERCE-1343 | 7.1.x-next - Remove deployment dependency of Jackson

### DIFF
--- a/commerce-openapi-core-impl/build.gradle
+++ b/commerce-openapi-core-impl/build.gradle
@@ -29,5 +29,4 @@ deployDependencies {
 	from configurations.compileOnly
 
 	include "aalto-xml-*.jar"
-	include "jackson-*.jar"
 }


### PR DESCRIPTION
[Commerce API Scrum board](https://issues.liferay.com/secure/RapidBoard.jspa?rapidView=3928)
----
Ticket: https://issues.liferay.com/browse/COMMERCE-1343

According to @brianchandotcom 's email I remove Jackson dependency from our old APIs to not collide with the one that `portal-vulcan` deploys.

>portal-vulcan-api 2.0.0 is for 7.1.x
>All jars published now. Will be in next FP.

/cc @ethanbustad @marco-leo 