### PR TITLE
Revert "COMMERCE-1579 Don't add checkoutSteps to the registry if they…

### DIFF
--- a/commerce-checkout-web/src/main/java/com/liferay/commerce/checkout/web/internal/util/CommerceCheckoutStepServicesTrackerImpl.java
+++ b/commerce-checkout-web/src/main/java/com/liferay/commerce/checkout/web/internal/util/CommerceCheckoutStepServicesTrackerImpl.java
@@ -98,8 +98,6 @@ public class CommerceCheckoutStepServicesTrackerImpl
 				commerceCheckoutStepServiceWrapper.getService();
 
 			if (commerceCheckoutStep.isActive(
-					httpServletRequest, httpServletResponse) &&
-				commerceCheckoutStep.isVisible(
 					httpServletRequest, httpServletResponse)) {
 
 				commerceCheckoutSteps.add(commerceCheckoutStep);


### PR DESCRIPTION
…'re not visible"

This reverts commit cee472354e9e8fd8ed3dad68816f9fc5b8ebeceb.

@alecsloan 
Since some checkout steps are not visible but needed we can't remove them.
For example payment process checkout step.