### PR TITLE
COMMERCE-2080 Account MGMT organizations table is now wider

### DIFF
--- a/commerce-account-web/src/main/resources/META-INF/resources/view_account_info.jsp
+++ b/commerce-account-web/src/main/resources/META-INF/resources/view_account_info.jsp
@@ -20,17 +20,15 @@
 CommerceAccountDisplayContext commerceAccountDisplayContext = (CommerceAccountDisplayContext)request.getAttribute(WebKeys.PORTLET_DISPLAY_CONTEXT);
 %>
 
-<div class="container-fluid-1280">
-	<commerce-ui:table
-		dataProviderKey="<%= CommerceAccountOrganizationClayTable.NAME %>"
-		filter="<%= commerceAccountDisplayContext.getAccountFilter() %>"
-		itemPerPage="<%= 5 %>"
-		namespace="<%= renderResponse.getNamespace() %>"
-		pageNumber="1"
-		portletURL="<%= commerceAccountDisplayContext.getPortletURL() %>"
-		tableName="<%= CommerceAccountOrganizationClayTable.NAME %>"
-	/>
-</div>
+<commerce-ui:table
+	dataProviderKey="<%= CommerceAccountOrganizationClayTable.NAME %>"
+	filter="<%= commerceAccountDisplayContext.getAccountFilter() %>"
+	itemPerPage="<%= 5 %>"
+	namespace="<%= renderResponse.getNamespace() %>"
+	pageNumber="1"
+	portletURL="<%= commerceAccountDisplayContext.getPortletURL() %>"
+	tableName="<%= CommerceAccountOrganizationClayTable.NAME %>"
+/>
 
 <c:if test="<%= commerceAccountDisplayContext.hasCommerceAccountModelPermissions(CommerceAccountActionKeys.MANAGE_ORGANIZATIONS) %>">
 	<div class="commerce-cta is-visible">


### PR DESCRIPTION
Removed unnecessary wrapper. The JSP is called *nowhere* else but in the `commerce-account-web` package and the correct wrapping is already handled through the `<liferay-frontend:screen-navigation>` taglib from the `view_account.jsp` context. Which is the one responsible to wrap the current JSP.