### PR TITLE
COMMERCE-1699 Channel filters shown only if enabled

### DIFF
--- a/commerce-product-definitions-web/src/main/resources/META-INF/resources/edit_definition_channels.jsp
+++ b/commerce-product-definitions-web/src/main/resources/META-INF/resources/edit_definition_channels.jsp
@@ -37,26 +37,28 @@ long[] commerceChannelIds = cpDefinitionChannelDisplayContext.getCommerceChannel
 			<aui:fieldset>
 				<aui:input checked="<%= cpDefinition.isChannelFilterEnabled() %>" label="enable-filter-channels" name="channelFilterEnabled" type="toggle-switch" value="<%= cpDefinition.isChannelFilterEnabled() %>" />
 
-				<c:choose>
-					<c:when test="<%= commerceChannels.isEmpty() %>">
-						<div class="alert alert-info">
-							<liferay-ui:message key="there-are-no-channels" />
-						</div>
-					</c:when>
-					<c:otherwise>
+				<c:if test="<%= cpDefinition.isChannelFilterEnabled() %>">
+					<c:choose>
+						<c:when test="<%= commerceChannels.isEmpty() %>">
+							<div class="alert alert-info">
+								<liferay-ui:message key="there-are-no-channels" />
+							</div>
+						</c:when>
+						<c:otherwise>
 
-						<%
-						for (CommerceChannel commerceChannel : commerceChannels) {
-						%>
+							<%
+							for (CommerceChannel commerceChannel : commerceChannels) {
+							%>
 
-							<aui:input checked="<%= ArrayUtil.contains(commerceChannelIds, commerceChannel.getCommerceChannelId()) %>" label="<%= commerceChannel.getName() %>" name='<%= "commerceChannelId_" + commerceChannel.getCommerceChannelId() %>' onChange='<%= renderResponse.getNamespace() + "fulfillCommerceChannelIds();" %>' type="checkbox" value="<%= commerceChannel.getCommerceChannelId() %>" />
+								<aui:input checked="<%= ArrayUtil.contains(commerceChannelIds, commerceChannel.getCommerceChannelId()) %>" disabled="<%= !cpDefinition.isChannelFilterEnabled() %>" label="<%= commerceChannel.getName() %>" name='<%= "commerceChannelId_" + commerceChannel.getCommerceChannelId() %>' onChange='<%= renderResponse.getNamespace() + "fulfillCommerceChannelIds();" %>' type="checkbox" value="<%= commerceChannel.getCommerceChannelId() %>" />
 
-						<%
-						}
-						%>
+							<%
+							}
+							%>
 
-					</c:otherwise>
-				</c:choose>
+						</c:otherwise>
+					</c:choose>
+				</c:if>
 
 				<aui:button-row>
 					<aui:button cssClass="btn-lg" type="submit" />


### PR DESCRIPTION
This logic is debatable, as it forces the user to both enable *and* select the channels, with a double "Save" CTA. I followed the instructions of the JIRA ticket by the book, as we're nevertheless going to rewrite this completely through this Admin UI completion.