### PR TITLE
Fix integration test

### DIFF
--- a/commerce-product-type-virtual-order-service/src/main/java/com/liferay/commerce/product/type/virtual/order/service/impl/CommerceVirtualOrderItemLocalServiceImpl.java
+++ b/commerce-product-type-virtual-order-service/src/main/java/com/liferay/commerce/product/type/virtual/order/service/impl/CommerceVirtualOrderItemLocalServiceImpl.java
@@ -365,19 +365,19 @@ public class CommerceVirtualOrderItemLocalServiceImpl
 			CommerceVirtualOrderItem commerceVirtualOrderItem)
 		throws PortalException {
 
+		long duration = commerceVirtualOrderItem.getDuration();
+
+		if (duration == 0) {
+			return new Date(Long.MIN_VALUE);
+		}
+
 		User defaultUser = userLocalService.getDefaultUser(
 			commerceVirtualOrderItem.getCompanyId());
 
 		Calendar calendar = CalendarFactoryUtil.getCalendar(
 			defaultUser.getTimeZone());
 
-		long duration = commerceVirtualOrderItem.getDuration();
-
-		if (duration > 0) {
-			duration = calendar.getTimeInMillis() + duration;
-
-			calendar.setTimeInMillis(duration);
-		}
+		calendar.setTimeInMillis(calendar.getTimeInMillis() + duration);
 
 		return calendar.getTime();
 	}

--- a/commerce-product-type-virtual-order-test/src/testIntegration/java/com/liferay/commerce/product/type/virtual/order/service/test/CommerceVirtualOrderItemLocalServiceTest.java
+++ b/commerce-product-type-virtual-order-test/src/testIntegration/java/com/liferay/commerce/product/type/virtual/order/service/test/CommerceVirtualOrderItemLocalServiceTest.java
@@ -118,7 +118,7 @@ public class CommerceVirtualOrderItemLocalServiceTest {
 		CommerceCatalog commerceCatalog =
 			_commerceCatalogLocalService.addCommerceCatalog(
 				RandomTestUtil.randomString(), commerceCurrency.getCode(),
-				LocaleUtil.US.getDisplayLanguage(), null,
+				LocaleUtil.toLanguageId(LocaleUtil.US), null,
 				ServiceContextTestUtil.getServiceContext(
 					_company.getGroupId()));
 
@@ -128,8 +128,8 @@ public class CommerceVirtualOrderItemLocalServiceTest {
 
 		VirtualCPTypeTestUtil.addCPDefinitionVirtualSetting(
 			commerceCatalog.getGroupId(), cpDefinition.getModelClassName(),
-			cpDefinition.getCPDefinitionId(), 0L,
-			CommerceOrderConstants.ORDER_STATUS_TO_TRANSMIT, 0L, 0L, 0L);
+			cpDefinition.getCPDefinitionId(), 0,
+			CommerceOrderConstants.ORDER_STATUS_TO_TRANSMIT, 0, 0, 0);
 
 		CommerceTestUtil.addBackOrderCPDefinitionInventory(cpDefinition);
 
@@ -205,7 +205,7 @@ public class CommerceVirtualOrderItemLocalServiceTest {
 		CommerceCatalog commerceCatalog =
 			_commerceCatalogLocalService.addCommerceCatalog(
 				RandomTestUtil.randomString(), commerceCurrency.getCode(),
-				LocaleUtil.US.getDisplayLanguage(), null,
+				LocaleUtil.toLanguageId(LocaleUtil.US), null,
 				ServiceContextTestUtil.getServiceContext(
 					_company.getGroupId()));
 


### PR DESCRIPTION
Hey @marco-leo I think this should fix the test failure we're seeing e.g. here: https://github.com/liferay/com-liferay-commerce/pull/1786#issuecomment-564357009.

I think the test failure was valid -- we did have a bug in our code. In `CommerceVirtualOrderItemLocalServiceImpl.calculateCommerceVirtualOrderItemEndDate`, when `commerceVirtualOrderItem.getDuration()` was 0, would return essentially `new Date()` as the end date -- but that's either equal to or after the `Date startDate = new Date()` declared in `setDurationDates`! (Depending on how much time has passed in between, and when within the millisecond those calls occur.) So I think that's why we're seeing flaky results for this test -- sometimes it works the way we want it to, sometimes it doesn't.

Here's a diff that should fix it. Feel free to fix it a different way if you'd like.